### PR TITLE
Adiciona paginação ao dashboard de lembretes

### DIFF
--- a/views/layouts/main.handlebars
+++ b/views/layouts/main.handlebars
@@ -58,7 +58,7 @@
     </main>
 
     <footer class="bg-white shadow-md py-4 px-6 mt-6">
-        <p class="text-center text-gray-600">© 2023 Lembretes. Todos os direitos reservados.</p>
+        <p class="text-center text-gray-600">© 2025 Lembretes. Todos os direitos reservados.</p>
     </footer>
 
     </body>

--- a/views/reminder/dashboard.handlebars
+++ b/views/reminder/dashboard.handlebars
@@ -1,70 +1,85 @@
 <div class="bg-white rounded-lg shadow p-10"> 
-
     <h2 class="text-2xl font-bold text-left text-gray-800 mb-6">Dashboard</h2>
     <a href="/reminder/add" class="text-blue-500 underline">Criar lembrete</a>
-
-    <form action="/reminder/dashboard" method="GET" class="mb-6">
-        <div class="flex gap-2">
-            <input
-                type="text"
-                name="search"
-                placeholder="Buscar lembretes..."
-                class="w-full px-4 py-2 border rounded-lg shadow-sm focus:outline-none focus:ring focus:border-blue-300"
-                value="{{search}}"
-            />
-            <button
-                type="submit"
-                class="px-4 py-2 bg-blue-600 text-white rounded-lg hover:bg-blue-700"
-            >
-                Buscar
-            </button>
-        </div>
-    </form>
 
     <h3 class="text-xl font-semibold mt-6 mb-2">Lembretes</h3>
 
     {{#if reminders.length}}
         <ul class="space-y-4">
             {{#each reminders}}
-                <li class="p-4 border rounded-lg shadow-sm flex flex-row items-center justify-between">
-                    <h4 class="text-lg font-bold text-gray-700">{{title}}</h4>
-                    {{#if description}}
-                        <p class="text-gray-600">{{description}}</p>
-                    {{/if}}
-                    {{#if date}}
-                        <p class="text-sm text-gray-500">Data: {{date}}</p>
-                    {{/if}}
-                    <div class="group flex flex-row items-center justify-between gap-2">
-                        <a href="/reminder/edit/{{this.id}}" class="mt-2 bg-blue-500 text-white px-4 py-2 rounded hover:bg-blue-600">Editar</a>
-                        <form action="/reminder/remove" method="post" class="flex flex-col items-end">
-                            <input type="hidden" type="submit" name="id" value="{{id}}">
-                            <button type="submit" class="mt-2 bg-red-500 text-white px-4 py-2 rounded hover:bg-red-600">Excluir</button>
-                        </form>
+                <li class="p-4 border rounded-lg shadow-sm">
+                    <div class="flex flex-col md:flex-row md:items-center md:justify-between gap-2">
+                        <div>
+                            <h4 class="text-lg font-bold text-gray-700">{{title}}</h4>
+                            {{#if description}}
+                                <p class="text-gray-600">{{description}}</p>
+                            {{/if}}
+                            {{#if date}}
+                                <p class="text-sm text-gray-500">Data: {{date}}</p>
+                            {{/if}}
+                        </div>
+
+                        <div class="flex gap-2 mt-2 md:mt-0">
+                            <a href="/reminder/edit/{{this.id}}" class="text-green-700 hover:text-white border border-green-700 hover:bg-green-800 focus:ring-4 focus:outline-none focus:ring-green-300 font-medium rounded-lg text-sm px-5 py-2.5 text-center me-2 mb-2 dark:border-green-500 dark:text-green-500 dark:hover:text-white dark:hover:bg-green-600 dark:focus:ring-green-800 flex items-center gap-2 text-white px-4 py-2 rounded hover:bg-blue-600">
+                                <i class="fas fa-edit"></i> Editar
+                            </a>
+                            <button type="button" class="text-red-700 hover:text-white border border-red-700 hover:bg-red-800 focus:ring-4 focus:outline-none focus:ring-red-300 font-medium rounded-lg text-sm px-5 py-2.5 text-center me-2 mb-2 dark:border-red-500 dark:text-red-500 dark:hover:text-white dark:hover:bg-red-600 dark:focus:ring-red-900 flex items-center gap-2 text-white px-4 py-2 rounded hover:bg-red-600 delete-btn"
+                                data-id="{{id}}">
+                                <i class="fas fa-trash-alt"></i> Excluir
+                            </button>
+                        </div>
                     </div>
                 </li>
             {{/each}}
         </ul>
-
-        <div class="flex gap-2 mt-4">
-            {{#if currentPage}}
-                {{#if (gt currentPage 1)}}
-                    <a href="?page={{subtract currentPage 1}}&search={{search}}" class="px-3 py-1 bg-gray-200 rounded">Anterior</a>
-                {{/if}}
-            {{/if}}
-
-            {{#each (range 1 totalPages) as |page|}}
-                <a href="?page={{page}}&search={{../search}}" class="px-3 py-1 {{#ifEquals ../currentPage page}}bg-blue-500 text-white{{else}}bg-gray-200{{/ifEquals}} rounded">
-                    {{page}}
-                </a>
-            {{/each}}
-
-            {{#if currentPage}}
-                {{#if (lt currentPage totalPages)}}
-                    <a href="?page={{add currentPage 1}}&search={{search}}" class="px-3 py-1 bg-gray-200 rounded">Próximo</a>
-                {{/if}}
-            {{/if}}
-        </div>
     {{else}}
         <p class="text-gray-500">Nenhum lembrete cadastrado.</p>
     {{/if}}
 </div>
+
+<!-- Modal de Confirmação -->
+<div id="deleteModal" class="fixed inset-0 flex items-center justify-center bg-black bg-opacity-50 z-50 hidden">
+    <div class="bg-white rounded-lg shadow-xl w-full max-w-md p-6">
+        <h2 class="text-xl font-semibold text-gray-800 mb-4">Deseja realmente excluir este lembrete?</h2>
+        <div class="flex justify-end space-x-4">
+            <button id="cancelDelete" class="px-4 py-2 bg-gray-300 rounded hover:bg-gray-400 text-gray-800">
+                Cancelar
+            </button>
+            <form id="confirmDeleteForm" method="POST" action="">
+                <input type="hidden" name="id" id="deleteIdInput" value="">
+                <button type="submit" class="px-4 py-2 bg-red-600 text-white rounded hover:bg-red-700">
+                    Confirmar Exclusão
+                </button>
+            </form>
+        </div>
+    </div>
+</div>
+
+<script>
+    document.addEventListener('DOMContentLoaded', () => {
+        const deleteModal = document.getElementById('deleteModal');
+        const cancelBtn = document.getElementById('cancelDelete');
+        const confirmForm = document.getElementById('confirmDeleteForm');
+        const deleteIdInput = document.getElementById('deleteIdInput');
+        const deleteBtns = document.querySelectorAll('.delete-btn');
+
+        deleteBtns.forEach(btn => {
+            btn.addEventListener('click', () => {
+                const id = btn.getAttribute('data-id');
+                deleteIdInput.value = id;
+                confirmForm.action = '/reminder/remove';
+                deleteModal.classList.remove('hidden');
+            });
+        });
+
+        cancelBtn.addEventListener('click', () => {
+            deleteModal.classList.add('hidden');
+        });
+
+        window.addEventListener('click', (e) => {
+            if (e.target === deleteModal) {
+                deleteModal.classList.add('hidden');
+            }
+        });
+    });
+</script>

--- a/views/reminder/dashboard.handlebars
+++ b/views/reminder/dashboard.handlebars
@@ -1,6 +1,25 @@
 <div class="bg-white rounded-lg shadow p-10"> 
+
     <h2 class="text-2xl font-bold text-left text-gray-800 mb-6">Dashboard</h2>
     <a href="/reminder/add" class="text-blue-500 underline">Criar lembrete</a>
+
+    <form action="/reminder/dashboard" method="GET" class="mb-6">
+        <div class="flex gap-2">
+            <input
+                type="text"
+                name="search"
+                placeholder="Buscar lembretes..."
+                class="w-full px-4 py-2 border rounded-lg shadow-sm focus:outline-none focus:ring focus:border-blue-300"
+                value="{{search}}"
+            />
+            <button
+                type="submit"
+                class="px-4 py-2 bg-blue-600 text-white rounded-lg hover:bg-blue-700"
+            >
+                Buscar
+            </button>
+        </div>
+    </form>
 
     <h3 class="text-xl font-semibold mt-6 mb-2">Lembretes</h3>
 
@@ -25,6 +44,26 @@
                 </li>
             {{/each}}
         </ul>
+
+        <div class="flex gap-2 mt-4">
+            {{#if currentPage}}
+                {{#if (gt currentPage 1)}}
+                    <a href="?page={{subtract currentPage 1}}&search={{search}}" class="px-3 py-1 bg-gray-200 rounded">Anterior</a>
+                {{/if}}
+            {{/if}}
+
+            {{#each (range 1 totalPages) as |page|}}
+                <a href="?page={{page}}&search={{../search}}" class="px-3 py-1 {{#ifEquals ../currentPage page}}bg-blue-500 text-white{{else}}bg-gray-200{{/ifEquals}} rounded">
+                    {{page}}
+                </a>
+            {{/each}}
+
+            {{#if currentPage}}
+                {{#if (lt currentPage totalPages)}}
+                    <a href="?page={{add currentPage 1}}&search={{search}}" class="px-3 py-1 bg-gray-200 rounded">Próximo</a>
+                {{/if}}
+            {{/if}}
+        </div>
     {{else}}
         <p class="text-gray-500">Nenhum lembrete cadastrado.</p>
     {{/if}}


### PR DESCRIPTION
Este PR implementa a funcionalidade de paginação na listagem de lembretes do dashboard. Agora, os lembretes são exibidos em páginas com limite definido, e os usuários podem navegar entre as páginas usando botões "Anterior", "Próximo" e links numerados.

Também foi adicionada a persistência do parâmetro de busca (search) na URL durante a navegação, garantindo que o filtro seja mantido ao mudar de página.

**Alterações principais**
Atualização do controller dashboard para suportar limit, offset, page e search.

Implementação da busca combinada com a paginação usando Sequelize.

Adição dos dados currentPage, totalPages, search e total no res.render.

Atualização da view do dashboard para exibir os lembretes em tabela e mostrar os controles de paginação com base nos dados recebidos.

**Testes manuais realizados**
Acessar o dashboard logado.

Usar o campo de busca e verificar se os resultados aparecem corretamente.

Navegar pelas páginas e confirmar se os lembretes estão sendo exibidos corretamente.

Validar a preservação da busca ao trocar de página.