### PR TITLE
Exibe visualmente o status do lembrete na dashboard

### DIFF
--- a/controllers/ReminderController.js
+++ b/controllers/ReminderController.js
@@ -168,6 +168,8 @@ module.exports = class ReminderController {
                 reminder.dateFormatted = reminder.date.toISOString().slice(0, 10);
             }
 
+            console.log('Reminder to edit:', reminder);
+
             res.render('reminder/edit', { reminder });
 
         } catch (err) {
@@ -187,6 +189,7 @@ module.exports = class ReminderController {
             title: req.body.title,
             description: req.body.description,
             date,
+            post_status: req.body.post_status || 'publish',
         };
         
         try {

--- a/views/reminder/dashboard.handlebars
+++ b/views/reminder/dashboard.handlebars
@@ -20,6 +20,14 @@
                             {{#if date}}<p class="text-sm text-gray-500">Data: {{date}}</p>{{/if}}
                         </div>
 
+                        <div>
+                            {{#if post_status}}
+                                <span class="inline-block px-2 py-1 text-xs font-semibold rounded-full {{#if (eq post_status 'publish')}}bg-green-100 text-green-800{{else if (eq post_status 'draft')}}bg-yellow-100 text-yellow-800{{else}}bg-gray-100 text-gray-800{{/if}}">
+                                    {{post_status}}
+                                </span>
+                            {{/if}}
+                        </div>
+
                         <div class="flex gap-2 mt-2 md:mt-0">
                             <a href="/reminder/edit/{{this.id}}" class="border border-green-700 text-green-700 hover:bg-green-800 hover:text-white focus:ring-4 focus:ring-green-300 font-medium rounded-lg text-sm px-4 py-2 flex items-center gap-2">
                                 <i class="fas fa-edit"></i> Editar

--- a/views/reminder/dashboard.handlebars
+++ b/views/reminder/dashboard.handlebars
@@ -24,7 +24,7 @@
                             {{#if post_status}}
                                 <span class="inline-block px-2 py-1 text-xs font-semibold rounded-full {{#if (eq post_status 'publish')}}bg-green-100 text-green-800{{else if (eq post_status 'draft')}}bg-yellow-100 text-yellow-800{{else}}bg-gray-100 text-gray-800{{/if}}">
                                     {{post_status}}
-                                </span>
+                                </span> 
                             {{/if}}
                         </div>
 

--- a/views/reminder/dashboard.handlebars
+++ b/views/reminder/dashboard.handlebars
@@ -1,7 +1,10 @@
 <div class="bg-white rounded-lg shadow p-10"> 
     <h2 class="text-2xl font-bold text-left text-gray-800 mb-6">Dashboard</h2>
+
     <div class="flex gap-2 mt-2 md:mt-0">
-    <a href="/reminder/add" class="text-green-700 hover:text-white border border-blue-700 hover:bg-blue-800 focus:ring-4 focus:outline-none focus:ring-blue-300 font-medium rounded-lg text-sm px-5 py-2.5 text-center me-2 mb-2 dark:border-blue-500 dark:text-blue-500 dark:hover:text-white dark:hover:bg-blue-600 dark:focus:ring-blue-800 flex items-center gap-2 text-white px-4 py-2 rounded hover:bg-blue-100">Criar lembrete</a>
+        <a href="/reminder/add" class="text-white bg-blue-700 hover:bg-blue-800 focus:ring-4 focus:outline-none focus:ring-blue-300 font-medium rounded-lg text-sm px-5 py-2.5 text-center flex items-center gap-2">
+            Criar lembrete
+        </a>
     </div>
 
     <h3 class="text-xl font-semibold mt-6 mb-2">Lembretes</h3>
@@ -13,55 +16,42 @@
                     <div class="flex flex-col md:flex-row md:items-center md:justify-between gap-2">
                         <div>
                             <h4 class="text-lg font-bold text-gray-700">{{title}}</h4>
-                            {{#if description}}
-                                <p class="text-gray-600">{{description}}</p>
-                            {{/if}}
-                            {{#if date}}
-                                <p class="text-sm text-gray-500">Data: {{date}}</p>
-                            {{/if}}
+                            {{#if description}}<p class="text-gray-600">{{description}}</p>{{/if}}
+                            {{#if date}}<p class="text-sm text-gray-500">Data: {{date}}</p>{{/if}}
                         </div>
 
                         <div class="flex gap-2 mt-2 md:mt-0">
-                            <a href="/reminder/edit/{{this.id}}" class="text-green-700 hover:text-white border border-green-700 hover:bg-green-800 focus:ring-4 focus:outline-none focus:ring-green-300 font-medium rounded-lg text-sm px-5 py-2.5 text-center me-2 mb-2 dark:border-green-500 dark:text-green-500 dark:hover:text-white dark:hover:bg-green-600 dark:focus:ring-green-800 flex items-center gap-2 text-white px-4 py-2 rounded hover:bg-blue-600">
+                            <a href="/reminder/edit/{{this.id}}" class="border border-green-700 text-green-700 hover:bg-green-800 hover:text-white focus:ring-4 focus:ring-green-300 font-medium rounded-lg text-sm px-4 py-2 flex items-center gap-2">
                                 <i class="fas fa-edit"></i> Editar
                             </a>
-                            <button type="button" class="text-red-700 hover:text-white border border-red-700 hover:bg-red-800 focus:ring-4 focus:outline-none focus:ring-red-300 font-medium rounded-lg text-sm px-5 py-2.5 text-center me-2 mb-2 dark:border-red-500 dark:text-red-500 dark:hover:text-white dark:hover:bg-red-600 dark:focus:ring-red-900 flex items-center gap-2 text-white px-4 py-2 rounded hover:bg-red-600 delete-btn"
+
+                            <button type="button" class="border border-red-700 text-red-700 hover:bg-red-800 hover:text-white focus:ring-4 focus:ring-red-300 font-medium rounded-lg text-sm px-4 py-2 flex items-center gap-2 delete-btn"
                                 data-id="{{id}}">
                                 <i class="fas fa-trash-alt"></i> Excluir
                             </button>
 
                             <button type="button"
-                                class="quick-edit-toggle font-medium rounded-lg text-sm px-4 py-2 text-center me-2 mb-2 flex items-center gap-2"
-                                style="color: #666666; border: 1px solid #666666;"
-                                onmouseover="this.style.backgroundColor='#666666'; this.style.color='white';"
-                                onmouseout="this.style.backgroundColor='transparent'; this.style.color='#666666';"
-                                data-id="3">
+                                class="quick-edit-toggle font-medium rounded-lg text-sm px-4 py-2 flex items-center gap-2 border border-gray-600 text-gray-600 hover:bg-gray-600 hover:text-white"
+                                data-id="{{this.id}}">
                                 <i class="fas fa-pen"></i> Edição rápida
                             </button>
-
                         </div>
                     </div>
 
-                    <div class="quick-edit-form hidden mt-4 flex flex-col md:flex-row md:items-center md:justify-between gap-2" data-id="{{this.id}}">
-                        <div>
-                            <form action="/reminder/edit/{{this.id}}" method="POST" class="space-y-2">
-                                
-                                <input type="hidden" name="quick_edit" value="1">
+                    <div class="quick-edit-form hidden mt-4 flex flex-col gap-2" data-id="{{this.id}}">
+                        <form action="/reminder/edit/{{this.id}}" method="POST" class="space-y-2 w-full">
+                            <input type="hidden" name="quick_edit" value="1">
+                            <input type="text" name="title" value="{{title}}" class="w-full border p-2 rounded" placeholder="Título">
+                            <textarea name="description" class="w-full border p-2 rounded" placeholder="Descrição">{{description}}</textarea>
+                            <input type="date" name="date" value="{{dateFormatted}}" class="w-full border p-2 rounded">
 
-                                <input type="text" name="title" value="{{title}}" class="w-full border p-2 rounded" placeholder="Título">
-                                <textarea name="description" class="w-full border p-2 rounded" placeholder="Descrição">{{description}}</textarea>
-                                <input type="date" name="date" value="{{dateFormatted}}" class="w-full border p-2 rounded">
-                                <div class="flex justify-end gap-2">
-                                    <button type="submit" class="bg-blue-600 text-white px-4 py-2 rounded">Salvar</button>
-                                </div>
-                            </form>
-                        </div>
-                        <div class="flex justify-end mt-2 md:mt-0">
-                            <button class="cancel-quick-edit bg-gray-300 text-gray-700 px-4 py-2 rounded">Cancelar</button>     
-                        </div>
+                            <div class="flex justify-end gap-2">
+                                <button type="submit" class="bg-blue-600 text-white px-4 py-2 rounded">Salvar</button>
+                                <button type="button" class="cancel-quick-edit bg-gray-300 text-gray-700 px-4 py-2 rounded">Cancelar</button>
+                            </div>
+                        </form>
                     </div>
                 </li>
-                
             {{/each}}
         </ul>
     {{else}}
@@ -69,6 +59,7 @@
     {{/if}}
 </div>
 
+<!-- Modal de exclusão -->
 <div id="deleteModal" class="fixed inset-0 flex items-center justify-center bg-black bg-opacity-50 z-50 hidden">
     <div class="bg-white rounded-lg shadow-xl w-full max-w-md p-6">
         <h2 class="text-xl font-semibold text-gray-800 mb-4">Deseja realmente excluir este lembrete?</h2>
@@ -88,7 +79,7 @@
 
 <script>
     document.addEventListener('DOMContentLoaded', () => {
-        // Exclusão já existente
+        // Modal de exclusão
         const deleteModal = document.getElementById('deleteModal');
         const cancelBtn = document.getElementById('cancelDelete');
         const confirmForm = document.getElementById('confirmDeleteForm');
@@ -97,7 +88,7 @@
 
         deleteBtns.forEach(btn => {
             btn.addEventListener('click', () => {
-                const id = btn.getAttribute('data-id');
+                const id = btn.dataset.id;
                 deleteIdInput.value = id;
                 confirmForm.action = '/reminder/remove';
                 deleteModal.classList.remove('hidden');
@@ -108,22 +99,22 @@
             deleteModal.classList.add('hidden');
         });
 
-        window.addEventListener('click', (e) => {
+        window.addEventListener('click', e => {
             if (e.target === deleteModal) {
                 deleteModal.classList.add('hidden');
             }
         });
 
-        // Edição Rápida
+        // Edição rápida
         const toggleButtons = document.querySelectorAll('.quick-edit-toggle');
         const quickForms = document.querySelectorAll('.quick-edit-form');
 
         toggleButtons.forEach(btn => {
             btn.addEventListener('click', () => {
-                const id = btn.getAttribute('data-id');
+                const id = btn.dataset.id;
 
                 quickForms.forEach(form => {
-                    if (form.getAttribute('data-id') === id) {
+                    if (form.dataset.id === id) {
                         form.classList.toggle('hidden');
                     } else {
                         form.classList.add('hidden');
@@ -132,13 +123,13 @@
             });
         });
 
-        // Botão de cancelar
+        // Cancelar edição rápida
         const cancelButtons = document.querySelectorAll('.cancel-quick-edit');
-        cancelButtons.forEach(cancel => {
-            cancel.addEventListener('click', () => {
-                cancel.closest('.quick-edit-form').classList.add('hidden');
+        cancelButtons.forEach(btn => {
+            btn.addEventListener('click', () => {
+                const form = btn.closest('.quick-edit-form');
+                form.classList.add('hidden');
             });
         });
     });
 </script>
-


### PR DESCRIPTION
Adicionei um badge colorido para exibir o campo post_status (como publish, draft, etc.) ao lado de cada lembrete na lista da dashboard.

Cada status tem uma cor diferente para facilitar a identificação:

- Publicados (publish) aparecem em verde

- Rascunhos (draft) aparecem em amarelo

- Outros status aparecem em cinza