### PR TITLE
chore: adiciona @faker-js/faker como dependência de desenvolvimento

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -31,6 +31,7 @@
       "devDependencies": {
         "@babel/core": "^7.27.4",
         "@babel/preset-env": "^7.27.2",
+        "@faker-js/faker": "^9.9.0",
         "babel-loader": "^10.0.0",
         "nodemon": "^3.1.10",
         "webpack-cli": "^6.0.1"
@@ -1560,6 +1561,23 @@
       "license": "MIT",
       "engines": {
         "node": ">=14.17.0"
+      }
+    },
+    "node_modules/@faker-js/faker": {
+      "version": "9.9.0",
+      "resolved": "https://registry.npmjs.org/@faker-js/faker/-/faker-9.9.0.tgz",
+      "integrity": "sha512-OEl393iCOoo/z8bMezRlJu+GlRGlsKbUAN7jKB6LhnKoqKve5DXRpalbItIIcwnCjs1k/FOPjFzcA6Qn+H+YbA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fakerjs"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.0.0",
+        "npm": ">=9.0.0"
       }
     },
     "node_modules/@isaacs/cliui": {

--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
   "devDependencies": {
     "@babel/core": "^7.27.4",
     "@babel/preset-env": "^7.27.2",
+    "@faker-js/faker": "^9.9.0",
     "babel-loader": "^10.0.0",
     "nodemon": "^3.1.10",
     "webpack-cli": "^6.0.1"


### PR DESCRIPTION
Este PR adiciona a biblioteca @faker-js/faker como uma dependência de desenvolvimento.
Essa biblioteca será usada para gerar dados fictícios em testes, seeds e mocks durante o desenvolvimento.

Comando utilizado:
npm install @faker-js/faker --save-dev
