### PR TITLE
feat: adicionar suporte a status "Agendado" ao escolher data futura

### DIFF
--- a/controllers/ReminderController.js
+++ b/controllers/ReminderController.js
@@ -111,6 +111,7 @@ module.exports = class ReminderController {
                     reminder.dateFormatted_expire = formatForDatetimeLocal(reminder.post_expire);
                 }
             });
+            
 
             const showPagination = total > limit;
             const paginationHtml = renderPagination(page, pages, showPagination, search, showDeleted);
@@ -202,6 +203,8 @@ module.exports = class ReminderController {
                 reminder.dateFormatted_expire = formatForDatetimeLocal(reminder.post_expire);
             }
 
+            console.log(reminder)
+
             res.render('reminder/edit', { reminder });
 
         } catch (err) {
@@ -288,7 +291,6 @@ module.exports = class ReminderController {
                 where: { id, UserId },
                 force: true 
             });
-
 
             console.log('Resultado da remoção:', deleted);
 

--- a/models/Reminder.js
+++ b/models/Reminder.js
@@ -24,7 +24,7 @@ const Reminder = db.define('Reminder', {
         allowNull: true,
     },
     post_status: {
-        type: DataTypes.ENUM('draft', 'published', 'pending', 'expired'),
+        type: DataTypes.ENUM('draft', 'published', 'pending', 'expired', 'scheduled'),
         allowNull: true,
         defaultValue: 'draft'
     },
@@ -39,7 +39,7 @@ const Reminder = db.define('Reminder', {
 }, {
     paranoid: true,             // Habilita soft delete
     deletedAt: 'deletedAt',     // Define o campo usado para marcação de exclusão
-    timestamps: true,           // Garante o uso de createdAt e updatedAt
+    timestamps: true,           // Garante o uso de createdAt e updatedAt 
     tableName: 'Reminders'      // (opcional) define o nome da tabela explicitamente
 });
 

--- a/views/reminder/create.handlebars
+++ b/views/reminder/create.handlebars
@@ -44,7 +44,9 @@
             <option value="draft">Rascunho</option>
             <option value="published">Publicado</option>
             <option value="pending">Pendente</option>
+            <option value="scheduled">Agendado</option>
           </select>
+
         </div>
 
         <button type="submit" id="submitBtn"
@@ -76,4 +78,34 @@
       loader.classList.remove('hidden');
     });
   });
+
+  document.addEventListener('DOMContentLoaded', () => {
+    const btn = document.getElementById('submitBtn');
+    const loader = document.getElementById('btnLoader');
+    const text = document.getElementById('btnText');
+    const dateInput = document.getElementById('date');
+    const statusSelect = document.getElementById('post_status');
+
+    btn.addEventListener('click', function (e) {
+
+      const selectedDate = new Date(dateInput.value);
+      const now = new Date();
+
+      if (dateInput.value && selectedDate > now) {
+
+        let option = [...statusSelect.options].find(o => o.value === "scheduled");
+
+        if (!option) {
+          option = new Option("Agendado", "scheduled");
+          statusSelect.add(option);
+        }
+
+        statusSelect.value = "scheduled";
+      }
+
+      text.classList.add('hidden');
+      loader.classList.remove('hidden');
+    });
+  });
 </script>
+

--- a/views/reminder/dashboard.handlebars
+++ b/views/reminder/dashboard.handlebars
@@ -56,11 +56,13 @@
                   {{else if (eq post_status 'draft')}}bg-yellow-100 text-yellow-700
                   {{else if (eq post_status 'pending')}}bg-orange-100 text-orange-700
                   {{else if (eq post_status 'expired')}}bg-red-100 text-red-700
+                  {{else if (eq post_status 'scheduled')}}bg-green-100 text-green-700
                   {{else}}bg-gray-100 text-gray-800{{/if}}" data-status="{{this.id}}">
                   {{#if (eq post_status 'draft')}}Rascunho
                   {{else if (eq post_status 'published')}}Publicado
                   {{else if (eq post_status 'pending')}}Pendente
                   {{else if (eq post_status 'expired')}}Expirado
+                  {{else if (eq post_status 'scheduled')}}Agendado
                   {{else}}{{post_status}}{{/if}}
                 </span>
               {{else}}
@@ -101,16 +103,22 @@
               <textarea name="description" class="w-full border p-2 rounded" placeholder="Descrição">{{description}}</textarea>
 
               <label for="date" class="block text-gray-700 font-medium">Data</label>
-              <input type="date" name="date" value="{{dateFormatted}}" class="w-full border p-2 rounded" step="1">
+                <input type="datetime-local" id="date" name="date" value="{{dateFormatted}}" step="1"
+                    class="w-full mt-1 p-2 border border-gray-300 rounded focus:outline-none focus:ring-2 focus:ring-blue-500" />
 
               <label for="post_expire" class="block text-gray-700 font-medium">Data de expiração</label>
-              <input type="date" name="post_expire" value="{{dateFormatted_expire}}" class="w-full border p-2 rounded" step="1">
+               <input type="datetime-local" id="post_expire" name="post_expire" value="{{dateFormatted_expire}}" step="1"
+                        class="w-full mt-1 p-2 border border-gray-300 rounded focus:outline-none focus:ring-2 focus:ring-blue-500" />
+
+               {{log dateFormatted}}
+               {{log dateFormatted_expire}}
 
               <label for="post_status" class="block text-gray-700 font-medium">Status</label>
               <select id="post_status" name="post_status" class="w-full mt-1 p-2 border border-gray-300 rounded focus:outline-none focus:ring-2 focus:ring-blue-500">
                 <option value="draft" {{#if (eq post_status "draft")}}selected{{/if}}>Rascunho</option>
                 <option value="published" {{#if (eq post_status "published")}}selected{{/if}}>Publicado</option>
                 <option value="pending" {{#if (eq post_status "pending")}}selected{{/if}}>Pendente</option>
+                <option value="scheduled" {{#if (eq post_status "scheduled")}}selected{{/if}}>Agendado</option>
               </select>
 
               <div class="flex justify-end gap-2">

--- a/views/reminder/edit.handlebars
+++ b/views/reminder/edit.handlebars
@@ -58,6 +58,7 @@
                     <option value="published" {{#if (eq reminder.post_status "published")}}selected{{/if}}>Publicado</option>
                     <option value="pending" {{#if (eq reminder.post_status "pending")}}selected{{/if}}>Pendente</option>
                     <option value="expired" {{#if (eq reminder.post_status "expired")}}selected{{/if}}>Expirado</option>
+                    <option value="scheduled" {{#if (eq reminder.post_status "scheduled")}}selected{{/if}}>Agendado</option>
                 </select>
             </div>
 


### PR DESCRIPTION
📖 Descrição do PR

Este PR adiciona a funcionalidade de definir automaticamente o status como "Agendado" quando o usuário seleciona uma data futura no campo date.

**Alterações realizadas:**

Adicionado a opção Agendado (scheduled) no select de status da publicação.

**Criada lógica em JavaScript que:**

Detecta quando o usuário seleciona uma data maior que a atual.

Atualiza automaticamente o campo post_status para "scheduled".

Mantida a lógica de loading no botão Salvar.