### PR TITLE
Atualização da Model Reminder com suporte a Slug Automático

### DIFF
--- a/controllers/ReminderController.js
+++ b/controllers/ReminderController.js
@@ -2,6 +2,7 @@ const sequelizePaginate = require('sequelize-paginate');
 const Reminder = require('../models/Reminder');
 const User = require('../models/User');
 const renderPagination = require('../components/pagination');
+const slugify = require('slugify');
 const { Op } = require('sequelize'); 
 const { isValid, parseISO } = require('date-fns');
 const { formatForDatetimeLocal } = require('../helpers/parseFormat')
@@ -161,8 +162,15 @@ module.exports = class ReminderController {
                 date = new Date();
             }
 
+            const title =  req.body.title
+
+            const slug = slugify(title, {
+                lower: true,    // deixa tudo minúsculo
+                strict: true    // remove caracteres especiais
+            });
+            
             const reminder = {
-                title: req.body.title,
+                title,
                 description: req.body.description,
                 post_content: req.body.post_content || '',
                 date, // sempre terá valor válido aqui
@@ -236,7 +244,7 @@ module.exports = class ReminderController {
             data = req.body;
         }
 
-        const { title, description, post_status, post_expire, date: rawDate } = data;
+        const { title, slug, description, post_status, post_expire, date: rawDate } = data;
 
         try {
             let date;
@@ -248,9 +256,20 @@ module.exports = class ReminderController {
                 date = new Date(); // se não veio nada, usa agora
             }
 
+            // const title = slugify(title, {
+            //     lower: true,     
+            //     strict: true  
+            // });
+
+            // const slug = slugify(slug, {
+            //     lower: true,    
+            //     strict: true  
+            // });
+
             const [updatedRows] = await Reminder.update(
                 {
                     title,
+                    slug,
                     description,
                     date,
                     post_status: post_status || 'draft',

--- a/models/Reminder.js
+++ b/models/Reminder.js
@@ -1,49 +1,66 @@
 const { DataTypes } = require('sequelize');
+const slugify = require('slugify');
 const db = require('../db/conn');
 const User = require('./User');
 
 const Reminder = db.define('Reminder', {
-    title: {
-        type: DataTypes.STRING,
-        allowNull: false,
-    },
-    description: {
-        type: DataTypes.TEXT,
-        allowNull: true,
-    },
-    post_content: {
-        type: DataTypes.TEXT,
-        allowNull: true,
-    },
-    date: {
-        type: DataTypes.DATE,
-        allowNull: true,
-    },
-    post_expire: {
-        type: DataTypes.DATE,
-        allowNull: true,
-    },
-    post_status: {
-        type: DataTypes.ENUM('draft', 'published', 'pending', 'expired', 'scheduled'),
-        allowNull: true,
-        defaultValue: 'draft'
-    },
-    deletedAt: {
-        type: DataTypes.DATE,
-        allowNull: true,
-    },
-    author: {
-        type: DataTypes.INTEGER,
-        allowNull: false,
-    } 
+  title: {
+    type: DataTypes.STRING,
+    allowNull: false,
+  },
+  slug: {
+    type: DataTypes.STRING,
+    allowNull: false,
+    unique: true, // Slug deve ser único
+  },
+  description: {
+    type: DataTypes.TEXT,
+    allowNull: true,
+  },
+  post_content: {
+    type: DataTypes.TEXT,
+    allowNull: true,
+  },
+  date: {
+    type: DataTypes.DATE,
+    allowNull: true,
+  },
+  post_expire: {
+    type: DataTypes.DATE,
+    allowNull: true,
+  },
+  post_status: {
+    type: DataTypes.ENUM('draft', 'published', 'pending', 'expired', 'scheduled'),
+    allowNull: true,
+    defaultValue: 'draft',
+  },
+  deletedAt: {
+    type: DataTypes.DATE,
+    allowNull: true,
+  },
+  author: {
+    type: DataTypes.INTEGER,
+    allowNull: false,
+  },
 }, {
-    paranoid: true,             // Habilita soft delete
-    deletedAt: 'deletedAt',     // Define o campo usado para marcação de exclusão
-    timestamps: true,           // Garante o uso de createdAt e updatedAt 
-    tableName: 'Reminders'      // (opcional) define o nome da tabela explicitamente
+  paranoid: true,             // habilita soft delete
+  deletedAt: 'deletedAt',     // define o campo usado para marcação de exclusão
+  timestamps: true,           // createdAt e updatedAt
+  tableName: 'Reminders',     // nome da tabela explicitamente
+  hooks: {
+    beforeValidate: (reminder) => {
+      if (reminder.title && !reminder.slug) {
+        reminder.slug = slugify(reminder.title, {
+          lower: true,
+          strict: true,
+        });
+      }
+    },
+  },
 });
 
-Reminder.belongsTo(User); 
-User.hasMany(Reminder);  
+// Relacionamentos
+Reminder.belongsTo(User, { foreignKey: 'author' });
+User.hasMany(Reminder, { foreignKey: 'author' });
 
 module.exports = Reminder;

--- a/package-lock.json
+++ b/package-lock.json
@@ -26,6 +26,7 @@
         "sequelize": "^6.37.7",
         "sequelize-paginate": "^1.1.6",
         "session-file-store": "^1.5.0",
+        "slugify": "^1.6.6",
         "zod": "^3.25.64"
       },
       "devDependencies": {
@@ -6589,6 +6590,15 @@
       },
       "engines": {
         "node": ">=10"
+      }
+    },
+    "node_modules/slugify": {
+      "version": "1.6.6",
+      "resolved": "https://registry.npmjs.org/slugify/-/slugify-1.6.6.tgz",
+      "integrity": "sha512-h+z7HKHYXj6wJU+AnS/+IH8Uh9fdcX1Lrhg1/VMdf9PwoBQXFcXiAdsy2tSK0P6gKwJLXp02r90ahUCqHk9rrw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8.0.0"
       }
     },
     "node_modules/snapdragon": {

--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
     "sequelize": "^6.37.7",
     "sequelize-paginate": "^1.1.6",
     "session-file-store": "^1.5.0",
+    "slugify": "^1.6.6",
     "zod": "^3.25.64"
   },
   "devDependencies": {

--- a/views/reminder/edit.handlebars
+++ b/views/reminder/edit.handlebars
@@ -15,6 +15,13 @@
         <input type="text" id="title" name="title"
           class="w-full mt-1 p-2 border border-gray-300 rounded focus:outline-none focus:ring-2 focus:ring-blue-500" 
           placeholder="Digite um título..." value="{{reminder.title}}" />
+      </div>
+
+      <div>
+        <label for="title" class="block text-gray-700 font-medium">Slug</label>
+        <input type="text" id="slug" name="slug"
+          class="w-full mt-1 p-2 border border-gray-300 rounded focus:outline-none focus:ring-2 focus:ring-blue-500" 
+          placeholder="Digite um slug" value="{{reminder.slug}}" />
       </div>  
 
       <div>


### PR DESCRIPTION
A lógica foi encapsulada diretamente no model Reminder por meio de um hook beforeValidate. Assim, ao criar ou atualizar um lembrete, o slug é gerado automaticamente caso não seja informado.

**Alterações principais**

Adicionada a dependência [slugify](https://www.npmjs.com/package/slugify) para conversão de títulos em slugs.

**Atualizada a model Reminder para incluir:**

- slug com unique: true e allowNull: false.

- Hook beforeValidate para gerar o slug automaticamente a partir do campo title.

Correção dos relacionamentos Reminder.belongsTo(User) e User.hasMany(Reminder) com foreignKey: 'author' para evitar criação de colunas inesperadas.